### PR TITLE
CMake: Optimize OpenMP linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,12 +99,9 @@ target_link_libraries(${PROJECT_NAME}
         Threads::Threads
 )
 
-# Apply OpenMP flags directly if enabled (without linking to interface target)
-if(DLP_ENABLE_OPENMP AND OpenMP_FOUND)
-    target_compile_options(${PROJECT_NAME} PRIVATE ${OpenMP_CXX_FLAGS})
-    if(OpenMP_CXX_LIBRARIES)
-        target_link_libraries(${PROJECT_NAME} PRIVATE ${OpenMP_CXX_LIBRARIES})
-    endif()
+# Link with OpenMP if enabled
+if(DLP_ENABLE_OPENMP)
+    target_link_libraries(${PROJECT_NAME} PRIVATE dlp::openmp)
 endif()
 
 # Link with dependencies for static library (no object libraries needed as they're included)
@@ -113,12 +110,9 @@ target_link_libraries(${PROJECT_NAME}_static
         Threads::Threads
 )
 
-# Apply OpenMP flags directly if enabled (without linking to interface target)
-if(DLP_ENABLE_OPENMP AND OpenMP_FOUND)
-    target_compile_options(${PROJECT_NAME}_static PRIVATE ${OpenMP_CXX_FLAGS})
-    if(OpenMP_CXX_LIBRARIES)
-        target_link_libraries(${PROJECT_NAME}_static PRIVATE ${OpenMP_CXX_LIBRARIES})
-    endif()
+# Link with OpenMP if enabled
+if(DLP_ENABLE_OPENMP)
+    target_link_libraries(${PROJECT_NAME}_static PRIVATE dlp::openmp)
 endif()
 
 # Add all sanitizers to the target

--- a/classic/CMakeLists.txt
+++ b/classic/CMakeLists.txt
@@ -54,8 +54,10 @@ target_include_directories(aocl_dlp_classic
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include> # For aocl_dlp_config.h
 )
 
-# Link with OpenMP for threading support
-target_link_libraries(aocl_dlp_classic PRIVATE dlp::openmp)
+# Link with OpenMP if enabled
+if(DLP_ENABLE_OPENMP)
+    target_link_libraries(aocl_dlp_classic PRIVATE dlp::openmp)
+endif()
 
 set(CLASSIC_TARGETS
     aocl_dlp_classic

--- a/cmake/dlp_dependencies.cmake
+++ b/cmake/dlp_dependencies.cmake
@@ -27,41 +27,28 @@
 # This file will be responsible for bringing in all dependencies
 
 #[==[
-Function to set up OpenMP dependency with flexibility for different environments.
+Function to set up OpenMP dependency using modern CMake best practices.
 This function:
-1. Tries to find the standard OpenMP package first
-2. Allows using LLVM OpenMP even with GCC compiler
-3. Respects custom OpenMP installations via environment variables
-   (LIBRARY_PATH, LD_LIBRARY_PATH, CMAKE_PREFIX_PATH, etc.)
-4. Creates an interface target for consistent usage throughout the project
+1. Uses CMake's built-in FindOpenMP module properly
+2. Creates a clean interface target for consistent usage
+3. Handles both C and C++ OpenMP targets
+4. Provides fallback options for custom installations
 
 Usage: dlp_setup_openmp()
 
 Variables affecting behavior:
-- DLP_ENABLE_OPENMP: Set to ON/OFF to enable/disable OpenMP support (default: ON)
-- DLP_USE_LLVM_OPENMP: Set to ON to force using LLVM OpenMP even with GCC
+- DLP_ENABLE_OPENMP: Set to ON/OFF to enable/disable OpenMP support
 - DLP_OPENMP_ROOT: Custom path to OpenMP installation root
 ]==]
 function(dlp_setup_openmp)
-    # Create an interface library for OpenMP
-    add_library(dlp_openmp_dep INTERFACE)
-
-    # Option for enabling/disabling OpenMP support
-    option(DLP_ENABLE_OPENMP "Enable OpenMP support for multithreading" ON)
-
     # Check if OpenMP is disabled first
     if(NOT DLP_ENABLE_OPENMP)
         message(STATUS "OpenMP support explicitly disabled")
-        # Make the interface library globally accessible
-        add_library(dlp::openmp ALIAS dlp_openmp_dep)
+        # Create a dummy interface target for consistency
+        add_library(dlp_openmp_interface INTERFACE)
+        add_library(dlp::openmp ALIAS dlp_openmp_interface)
         return()
     endif()
-
-    # Find and configure OpenMP with multiple options
-    include(FindOpenMP)
-
-    # Options for controlling OpenMP behavior
-    option(DLP_USE_LLVM_OPENMP "Force using LLVM OpenMP implementation even with GCC" OFF)
 
     # Allow user to specify a custom OpenMP root
     set(DLP_OPENMP_ROOT "" CACHE PATH "Path to custom OpenMP installation")
@@ -75,87 +62,40 @@ function(dlp_setup_openmp)
         list(APPEND CMAKE_PREFIX_PATH "${DLP_OPENMP_ROOT}")
     endif()
 
-    # Standard approach: try to find OpenMP using CMake's built-in module
-    find_package(OpenMP)
+    # Use CMake's built-in FindOpenMP module
+    find_package(OpenMP REQUIRED COMPONENTS C CXX)
 
     # Restore original prefix path
     if(DLP_OPENMP_ROOT)
         set(CMAKE_PREFIX_PATH "${_original_prefix_path}")
     endif()
 
-    # Check if we need to handle special cases
-    if(OpenMP_FOUND AND NOT DLP_USE_LLVM_OPENMP)
-        # Standard case: OpenMP was found and we don't need LLVM OpenMP
-        message(STATUS "Using standard OpenMP implementation")
+    if(OpenMP_FOUND)
+        message(STATUS "Found OpenMP: C flags=${OpenMP_C_FLAGS}, CXX flags=${OpenMP_CXX_FLAGS}")
 
-        # Explicitly ensure OpenMP compiler flags are included
-        target_compile_options(dlp_openmp_dep INTERFACE ${OpenMP_C_FLAGS})
-        target_link_libraries(dlp_openmp_dep INTERFACE OpenMP::OpenMP_C)
+        # Create our own interface target that combines both C and CXX OpenMP
+        add_library(dlp_openmp_interface INTERFACE)
 
+        # Link to the official OpenMP targets
+        target_link_libraries(dlp_openmp_interface INTERFACE
+            OpenMP::OpenMP_C
+            OpenMP::OpenMP_CXX
+        )
+
+        # Make the interface library globally accessible
+        add_library(dlp::openmp ALIAS dlp_openmp_interface)
+
+        # Set export name for the interface library
+        set_target_properties(dlp_openmp_interface PROPERTIES EXPORT_NAME openmp)
+
+        # Install the interface target so it can be exported
+        install(TARGETS dlp_openmp_interface
+            EXPORT AoclDlpTargets
+            INCLUDES DESTINATION include
+        )
+
+        message(STATUS "OpenMP integration configured successfully")
     else()
-        # Either OpenMP wasn't found or user explicitly requested LLVM OpenMP
-
-        if(DLP_USE_LLVM_OPENMP)
-            message(STATUS "Attempting to use LLVM OpenMP implementation as requested")
-        else()
-            message(STATUS "Standard OpenMP not found, trying LLVM OpenMP as fallback")
-        endif()
-
-        # Try to find LLVM OpenMP library
-        set(_openmp_lib_names "omp" "libomp" "libiomp")
-
-        # Look in common locations and environment variables
-        find_library(LLVM_OPENMP_LIBRARY
-            NAMES ${_openmp_lib_names}
-            PATHS
-                ${DLP_OPENMP_ROOT}
-                ENV LIBRARY_PATH
-                ENV LD_LIBRARY_PATH
-                /usr/lib
-                /usr/local/lib
-                /opt/llvm/lib
-            PATH_SUFFIXES lib lib64
-            DOC "LLVM OpenMP runtime library"
-        )
-
-        # Find OpenMP header
-        find_path(LLVM_OPENMP_INCLUDE
-            NAMES omp.h
-            PATHS
-                ${DLP_OPENMP_ROOT}
-                ENV CPATH
-                ENV C_INCLUDE_PATH
-                ENV CPLUS_INCLUDE_PATH
-                /usr/include
-                /usr/local/include
-                /opt/llvm/include
-            PATH_SUFFIXES include
-            DOC "LLVM OpenMP header"
-        )
-
-        if(LLVM_OPENMP_LIBRARY AND LLVM_OPENMP_INCLUDE)
-            message(STATUS "Found LLVM OpenMP: ${LLVM_OPENMP_LIBRARY}")
-            target_link_libraries(dlp_openmp_dep INTERFACE ${LLVM_OPENMP_LIBRARY})
-            target_include_directories(dlp_openmp_dep INTERFACE ${LLVM_OPENMP_INCLUDE})
-
-            # When using LLVM OpenMP with GCC, we may need to link to the pthread library too
-            if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-                find_package(Threads REQUIRED)
-                target_link_libraries(dlp_openmp_dep INTERFACE Threads::Threads)
-                target_link_libraries(dlp_openmp_dep INTERFACE ${CMAKE_DL_LIBS})
-                message(STATUS "Using LLVM OpenMP with GCC - adding additional dependencies")
-            endif()
-
-        else()
-            # No OpenMP implementation found
-            message(WARNING "No OpenMP implementation found. Multithreading will be disabled.")
-        endif()
-        # Explicitly add OpenMP compiler flag
-        target_compile_options(dlp_openmp_dep INTERFACE -fopenmp)
+        message(FATAL_ERROR "OpenMP was requested but not found. Please install OpenMP or set DLP_ENABLE_OPENMP=OFF")
     endif()
-
-    # Make the interface library globally accessible and exportable
-    add_library(dlp::openmp ALIAS dlp_openmp_dep)
-    # Set export name for the interface library
-    set_target_properties(dlp_openmp_dep PROPERTIES EXPORT_NAME openmp)
 endfunction()


### PR DESCRIPTION
Use cmake's own openmp finding and linkage mechanism than using manual openmp linkage mechanism.

This PR will abstract openmp into an interface target dlp::openmp.