### PR TITLE
Fix undefined behavior in BF16 GEMV N=1 mask computation

### DIFF
--- a/src/jit/amdzen/amdzen_generator.cc
+++ b/src/jit/amdzen/amdzen_generator.cc
@@ -1515,8 +1515,9 @@ jitAmdZenBF16::executeKernel(dlp::kernels::kernelParams* _params)
         params->k_left = params->k % numElemsPerReg;
 
         params->mmask_avx512 = 0xFFFF >> (MR - (params->m_left));
-        params->kmask_bf16_avx512 =
-            0xFFFFFFFF >> (numElemsPerReg - (params->k_left) % numElemsPerReg);
+        params->kmask_bf16_avx512 = static_cast<uint32_t>(
+            0xFFFFFFFFULL
+            >> (numElemsPerReg - (params->k_left) % numElemsPerReg));
 
         int is_m_loop = ((params->m) >= MR);
         // when rsC = 1, we logically have a col-major layout , where beta


### PR DESCRIPTION
When k is perfectly divisible by numElemsPerReg (32), k_left is 0 and the shift amount in the kmask_bf16_avx512 computation becomes 32, which is undefined behavior for the 32-bit literal 0xFFFFFFFF. Use a 64-bit literal (0xFFFFFFFFULL) with a cast to uint32_t so the shift is well-defined and produces the intended value of 0.