### PR TITLE
Support aliasing for MKL/OMP_NUM_THREADS and AOCL_ENABLE_INSTRUCTIONS

### DIFF
--- a/src/frame/env_utils/env_var_manager.cc
+++ b/src/frame/env_utils/env_var_manager.cc
@@ -99,6 +99,21 @@ constexpr std::array<std::string_view, 1> DLP_ARCH_ENV_VAR_STRINGS = {
     "AOCL_DLP_ENABLE_INSTRUCTIONS"
 };
 
+// Alias mappings: {primary, alias}
+// Iteration order encodes priority — higher-priority aliases come first.
+// If a higher-priority alias resolves, the primary key is cached and
+// lower-priority aliases are skipped.
+constexpr std::array<std::pair<std::string_view, std::string_view>, 2>
+    DLP_ENV_VAR_ALIASES = { {
+        { "DLP_NUM_THREADS", "MKL_NUM_THREADS" },
+        { "DLP_NUM_THREADS", "OMP_NUM_THREADS" },
+    } };
+
+constexpr std::array<std::pair<std::string_view, std::string_view>, 1>
+    DLP_ARCH_ENV_VAR_ALIASES = { {
+        { "AOCL_DLP_ENABLE_INSTRUCTIONS", "AOCL_ENABLE_INSTRUCTIONS" },
+    } };
+
 EnvironmentVariableManager::EnvironmentVariableManager()
 {
     for (const auto& env_var_name : DLP_ENV_VAR_STRINGS) {
@@ -117,6 +132,29 @@ EnvironmentVariableManager::EnvironmentVariableManager()
             // The arch env variable values are made case insensitive to
             // speed up its corresponding arch enum lookup.
             toLowerInPlace(env_cache_[std::string{ env_var_name }]);
+        }
+    }
+
+    // Resolve aliases for regular env vars.
+    for (const auto& [primary, alias] : DLP_ENV_VAR_ALIASES) {
+        if (env_cache_.find(std::string{ primary }) != env_cache_.end()) {
+            continue; // Primary already set, skip alias.
+        }
+        auto optVal = getRawEnvVar(alias);
+        if (optVal.has_value()) {
+            env_cache_[std::string{ primary }] = optVal.value();
+        }
+    }
+
+    // Resolve aliases for arch env vars (values lowered for lookup).
+    for (const auto& [primary, alias] : DLP_ARCH_ENV_VAR_ALIASES) {
+        if (env_cache_.find(std::string{ primary }) != env_cache_.end()) {
+            continue; // Primary already set, skip alias.
+        }
+        auto optVal = getRawEnvVar(alias);
+        if (optVal.has_value()) {
+            env_cache_[std::string{ primary }] = optVal.value();
+            toLowerInPlace(env_cache_[std::string{ primary }]);
         }
     }
 }

--- a/tests/classic/CMakeLists.txt
+++ b/tests/classic/CMakeLists.txt
@@ -49,3 +49,38 @@ foreach(test_source ${TEST_SOURCES})
     endif()
     dlp_set_global_compile_flags(${test_name} VISIBILITY PUBLIC)
 endforeach()
+
+#
+# Runtime threading tests with specific env var combos for alias resolution.
+# Each variant invokes the same test_runtime_threading binary under a
+# different environment, exercising the EnvVarAliasTest cases that key off
+# DLP_NUM_THREADS / MKL_NUM_THREADS / OMP_NUM_THREADS / AOCL_ENABLE_INSTRUCTIONS.
+# CTest ENVIRONMENT property takes a CMake list (semicolon-separated) of
+# KEY=VAL entries.
+#
+if(TARGET test_runtime_threading)
+    add_test(NAME test_runtime_threading_omp_alias
+             COMMAND test_runtime_threading)
+    set_tests_properties(test_runtime_threading_omp_alias PROPERTIES
+        ENVIRONMENT "OMP_NUM_THREADS=7")
+
+    add_test(NAME test_runtime_threading_mkl_alias
+             COMMAND test_runtime_threading)
+    set_tests_properties(test_runtime_threading_mkl_alias PROPERTIES
+        ENVIRONMENT "MKL_NUM_THREADS=5")
+
+    add_test(NAME test_runtime_threading_mkl_over_omp
+             COMMAND test_runtime_threading)
+    set_tests_properties(test_runtime_threading_mkl_over_omp PROPERTIES
+        ENVIRONMENT "MKL_NUM_THREADS=8;OMP_NUM_THREADS=16")
+
+    add_test(NAME test_runtime_threading_primary_wins
+             COMMAND test_runtime_threading)
+    set_tests_properties(test_runtime_threading_primary_wins PROPERTIES
+        ENVIRONMENT "DLP_NUM_THREADS=2;MKL_NUM_THREADS=8;OMP_NUM_THREADS=16")
+
+    add_test(NAME test_runtime_threading_instr_alias
+             COMMAND test_runtime_threading)
+    set_tests_properties(test_runtime_threading_instr_alias PROPERTIES
+        ENVIRONMENT "AOCL_ENABLE_INSTRUCTIONS=avx2")
+endif()

--- a/tests/classic/test_runtime_threading.cc
+++ b/tests/classic/test_runtime_threading.cc
@@ -342,7 +342,73 @@ TEST_F(ThreadingPrecedenceTest, UnsetLocalRestoresLibrary)
 }
 
 // ============================================================================
-// CATEGORY 3: OPENMP THREAD-LOCAL TESTS
+// CATEGORY 3: ENVIRONMENT VARIABLE ALIAS TESTS
+// ============================================================================
+
+/**
+ * Test: Thread count env var alias resolution
+ *
+ * Verifies the priority chain:
+ *   DLP_NUM_THREADS > MKL_NUM_THREADS > OMP_NUM_THREADS
+ *
+ * This single test covers all alias scenarios by checking which env vars
+ * are currently set and asserting the correct resolved value. Run via
+ * BUCK targets that set specific env var combinations.
+ */
+TEST(EnvVarAliasTest, ThreadCountAliasResolution)
+{
+    bool has_dlp = isEnvVarDefined("DLP_NUM_THREADS");
+    bool has_mkl = isEnvVarDefined("MKL_NUM_THREADS");
+    bool has_omp = isEnvVarDefined("OMP_NUM_THREADS");
+
+    if (!has_dlp && !has_mkl && !has_omp) {
+        // No thread-count alias env vars set — nothing to verify.
+        return;
+    }
+
+    md_t actual = dlp_thread_get_num_threads_active();
+
+    if (has_dlp) {
+        // Primary always wins over aliases.
+        EXPECT_EQ(actual, getEnvVarValue("DLP_NUM_THREADS"))
+            << "DLP_NUM_THREADS should take priority over MKL/OMP aliases";
+    } else if (has_mkl) {
+        // MKL alias takes priority over OMP.
+        EXPECT_EQ(actual, getEnvVarValue("MKL_NUM_THREADS"))
+            << "MKL_NUM_THREADS should take priority over OMP_NUM_THREADS";
+    } else {
+        // OMP is the lowest-priority alias.
+        EXPECT_EQ(actual, getEnvVarValue("OMP_NUM_THREADS"))
+            << "OMP_NUM_THREADS should be used as fallback";
+    }
+}
+
+/**
+ * Test: Instruction env var alias resolution
+ *
+ * Verifies: AOCL_ENABLE_INSTRUCTIONS resolves into
+ *           AOCL_DLP_ENABLE_INSTRUCTIONS when the primary is unset.
+ *
+ * Run via BUCK target with env = {"AOCL_ENABLE_INSTRUCTIONS": "avx2"}
+ */
+TEST(EnvVarAliasTest, InstructionAliasResolution)
+{
+    bool has_primary = isEnvVarDefined("AOCL_DLP_ENABLE_INSTRUCTIONS");
+    bool has_alias   = isEnvVarDefined("AOCL_ENABLE_INSTRUCTIONS");
+
+    if (!has_primary && !has_alias) {
+        // No instruction env vars set — nothing to verify.
+        return;
+    }
+
+    // If either the primary or the alias is set, the env cache should have
+    // resolved AOCL_DLP_ENABLE_INSTRUCTIONS, so this query returns true.
+    EXPECT_TRUE(dlp_aocl_enable_instruction_query())
+        << "Instruction env var should be resolved (primary or alias)";
+}
+
+// ============================================================================
+// CATEGORY 4: OPENMP THREAD-LOCAL TESTS
 // ============================================================================
 
 #ifdef DLP_ENABLE_OPENMP


### PR DESCRIPTION
Resolve DLP_NUM_THREADS from MKL_NUM_THREADS / OMP_NUM_THREADS and AOCL_DLP_ENABLE_INSTRUCTIONS from AOCL_ENABLE_INSTRUCTIONS when the primary env var is unset, with priority encoded by iteration order. Add EnvVarAliasTest gtest cases plus CTest variants that re-run the runtime threading binary under each env-var combo.