### PR TITLE
Fix nullptr-with-zero-offset ubsan issue in bf16 downscale path

### DIFF
--- a/classic/frame/bf16bf16f32/dlp_gemm_bf16.c
+++ b/classic/frame/bf16bf16f32/dlp_gemm_bf16.c
@@ -385,11 +385,12 @@ DLP_GEMM_5LOOP_AVX512BF16(bfloat16, bfloat16, float, bf16bf16f32of32)
                 &n_sub_updated);
         }
 
-        if (c_downscale == DLP_F32) {
-            c_use_jc = c + jc;
-        }
+        // This is for c_downscale == DLP_F32. When c_downscale < DLP_F32,
+        // this value will not be used.
+        c_use_jc = c + jc;
+
         // Temp accumulaton buffer for C allocation.
-        else if (c_downscale < DLP_F32) {
+        if (c_downscale < DLP_F32) {
             // Buffer memory is only required if output needs to be
             // persisted across iterations of the pc/KC loop.
             // It was observed that the locks used while checking out
@@ -1067,11 +1068,12 @@ DLP_GEMM_5LOOP_F32_FALLBACK(bfloat16, bfloat16, float, bf16bf16f32of32)
                 &n_sub_updated);
         }
 
-        if (c_downscale == DLP_F32) {
-            c_use_jc = c + jc;
-        }
+        // This is for c_downscale == DLP_F32. When c_downscale < DLP_F32,
+        // this value will not be used.
+        c_use_jc = c + jc;
+
         // Temp accumulaton buffer for C allocation.
-        else if (c_downscale < DLP_F32) {
+        if (c_downscale < DLP_F32) {
             // Buffer memory is only required if output needs to be
             // persisted across iterations of the pc/KC loop.
             // It was observed that the locks used while checking out

--- a/classic/frame/bf16bf16f32/dlp_gemm_bf16s4.c
+++ b/classic/frame/bf16bf16f32/dlp_gemm_bf16s4.c
@@ -178,11 +178,12 @@ DLP_GEMM_5LOOP_UNIFIED(bfloat16, int8_t, float, float, bf16s4f32of32, const)
             dlp_gemm_get_packb_strides(lcntx, &rs_b_use, &cs_b_use);
         }
 
-        if (c_downscale == DLP_F32) {
-            c_use_jc = c + jc;
-        }
+        // This is for c_downscale == DLP_F32. When c_downscale < DLP_F32,
+        // this value will not be used.
+        c_use_jc = c + jc;
+
         // Temp accumulaton buffer for C allocation.
-        else if (c_downscale < DLP_F32) {
+        if (c_downscale < DLP_F32) {
             // Buffer memory is only required if output needs to be
             // persisted across iterations of the pc/KC loop.
             // It was observed that the locks used while checking out

--- a/classic/frame/bf16bf16f32/dlp_gemm_bf16u4.c
+++ b/classic/frame/bf16bf16f32/dlp_gemm_bf16u4.c
@@ -184,11 +184,12 @@ DLP_GEMM_5LOOP_UNIFIED(bfloat16, uint8_t, float, float, bf16u4f32of32, const)
             dlp_gemm_get_packb_strides(lcntx, &rs_b_use, &cs_b_use);
         }
 
-        if (c_downscale == DLP_F32) {
-            c_use_jc = c + jc;
-        }
+        // This is for c_downscale == DLP_F32. When c_downscale < DLP_F32,
+        // this value will not be used.
+        c_use_jc = c + jc;
+
         // Temp accumulaton buffer for C allocation.
-        else if (c_downscale < DLP_F32) {
+        if (c_downscale < DLP_F32) {
             // Buffer memory is only required if output needs to be
             // persisted across iterations of the pc/KC loop.
             // It was observed that the locks used while checking out


### PR DESCRIPTION
When c_downscale < DLP_F32 (bf16 output) and k <= KC, the temporary float buffer for C was not allocated, leaving c_use_jc as NULL. Later pointer arithmetic c_use_ic = c_use_jc + offset triggered UBSan's 'applying zero offset to null pointer'. Always assign c_use_jc = c + jc so the arithmetic is well-defined; the value is unused when c_downscale < DLP_F32 (k <= KC path writes directly to buf_downscale).