### PR TITLE
bench: fix 4-bit byte accounting in benchmark metrics

### DIFF
--- a/bench/include/bench_metrics.hh
+++ b/bench/include/bench_metrics.hh
@@ -57,9 +57,9 @@ class BenchmarkMetrics
                                    MatrixType        c_type);
 
     /**
-     * @brief Get size in bytes for a matrix type
+     * @brief Get bytes-per-element for a matrix type.
      */
-    static size_t getMatrixTypeSize(MatrixType type);
+    static double getMatrixTypeSize(MatrixType type);
 };
 
 } // namespace dlp::benchmarking

--- a/bench/src/bench_metrics.cc
+++ b/bench/src/bench_metrics.cc
@@ -32,13 +32,13 @@
 
 namespace dlp::benchmarking {
 
-size_t
+double
 BenchmarkMetrics::getMatrixTypeSize(MatrixType type)
 {
     switch (type) {
         case MatrixType::u4:
         case MatrixType::s4:
-            return 1; // 4-bit types packed, but count as 1 byte min
+            return 0.5;
         case MatrixType::u8:
         case MatrixType::s8:
             return 1;
@@ -73,9 +73,9 @@ BenchmarkMetrics::calculateAndReport(benchmark::State& state,
 
     // For bandwidth calculation, we need bytes and will let Google Benchmark
     // calculate the rate
-    size_t size_a = getMatrixTypeSize(a_type);
-    size_t size_b = getMatrixTypeSize(b_type);
-    size_t size_c = getMatrixTypeSize(c_type);
+    double size_a = getMatrixTypeSize(a_type);
+    double size_b = getMatrixTypeSize(b_type);
+    double size_c = getMatrixTypeSize(c_type);
 
     double bytes_A     = static_cast<double>(m) * k * size_a;
     double bytes_B     = static_cast<double>(k) * n * size_b;

--- a/tests/bench/test_bench_utilities.cc
+++ b/tests/bench/test_bench_utilities.cc
@@ -50,7 +50,7 @@ namespace dlp::benchmarking {
 class BenchmarkMetrics
 {
   public:
-    static size_t getMatrixTypeSize(MatrixType type);
+        static double getMatrixTypeSize(MatrixType type);
 };
 } // namespace dlp::benchmarking
 
@@ -303,52 +303,52 @@ class MatrixTypeSizeTest : public ::testing::Test
 
 TEST_F(MatrixTypeSizeTest, U4TypeSize)
 {
-    EXPECT_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::u4), 1);
+    EXPECT_DOUBLE_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::u4), 0.5);
 }
 
 TEST_F(MatrixTypeSizeTest, S4TypeSize)
 {
-    EXPECT_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::s4), 1);
+    EXPECT_DOUBLE_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::s4), 0.5);
 }
 
 TEST_F(MatrixTypeSizeTest, U8TypeSize)
 {
-    EXPECT_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::u8), 1);
+    EXPECT_DOUBLE_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::u8), 1.0);
 }
 
 TEST_F(MatrixTypeSizeTest, S8TypeSize)
 {
-    EXPECT_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::s8), 1);
+    EXPECT_DOUBLE_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::s8), 1.0);
 }
 
 TEST_F(MatrixTypeSizeTest, U16TypeSize)
 {
-    EXPECT_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::u16), 2);
+    EXPECT_DOUBLE_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::u16), 2.0);
 }
 
 TEST_F(MatrixTypeSizeTest, S16TypeSize)
 {
-    EXPECT_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::s16), 2);
+    EXPECT_DOUBLE_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::s16), 2.0);
 }
 
 TEST_F(MatrixTypeSizeTest, BF16TypeSize)
 {
-    EXPECT_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::bf16), 2);
+    EXPECT_DOUBLE_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::bf16), 2.0);
 }
 
 TEST_F(MatrixTypeSizeTest, U32TypeSize)
 {
-    EXPECT_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::u32), 4);
+    EXPECT_DOUBLE_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::u32), 4.0);
 }
 
 TEST_F(MatrixTypeSizeTest, S32TypeSize)
 {
-    EXPECT_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::s32), 4);
+    EXPECT_DOUBLE_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::s32), 4.0);
 }
 
 TEST_F(MatrixTypeSizeTest, F32TypeSize)
 {
-    EXPECT_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::f32), 4);
+    EXPECT_DOUBLE_EQ(BenchmarkMetrics::getMatrixTypeSize(MatrixType::f32), 4.0);
 }
 
 // ============================================================================


### PR DESCRIPTION
u4/s4 benchmark metrics are now accounted as 0.5 bytes per element, and related benchmark utility tests were updated accordingly.