### PR TITLE
Implement nr loop JIT kernel for fp32 gemm tiny path to reduce the function call overhead

### DIFF
--- a/classic/frame/f32f32f32/dlp_gemm_f32f32f32_tiny.c
+++ b/classic/frame/f32f32f32/dlp_gemm_f32f32f32_tiny.c
@@ -427,26 +427,43 @@ DLP_GEMM_TINY(float, float, float, f32f32f32of32)
         ps_a_use = MR * rs_a;
     }
 
-    for (iter_t jr = 0; jr < n; jr += NR) {
-        md_t nr0 = dlp_min((n - jr), NR);
-
-        // Post ops meta attributes.
+    if (lcntx->dlp_kernel_hndl.kernel_base != NULL
+        && lcntx->dlp_kernel_hndl.hasNLoop) {
+        // nloop path: single JIT kernel call handles the full N dimension.
+        // Pass ps_b_use as cs_b so the JIT kernel can correctly advance B
+        // between NR panels. For packed B, ps_b_use = k (panel stride),
+        // while cs_b_use = 1 (element stride within a panel row).
         post_ops_attr.post_op_c_i    = 0;
-        post_ops_attr.post_op_c_j    = jr;
+        post_ops_attr.post_op_c_j    = 0;
         post_ops_attr.rs_c_downscale = rs_c_downscale;
+        dlp_execute_kernel_nloop(&(lcntx->dlp_kernel_hndl), m, n, k, (float*)a_use,
+                           rs_a_use, cs_a_use, ps_a_use, (float*)b_use,
+                           rs_b_use, ps_b_use, 0, 0, c, rs_c, cs_c_use,
+                           (void*)&alpha, (void*)&beta, post_op_list,
+                           post_ops_attr);
+    } else {
+        for (iter_t jr = 0; jr < n; jr += NR) {
+            md_t nr0 = dlp_min((n - jr), NR);
 
-        if (lcntx->dlp_kernel_hndl.kernel_base != NULL) {
-            dlp_execute_kernel(
-                &(lcntx->dlp_kernel_hndl), m, nr0, k, (float*)a_use, rs_a_use,
-                cs_a_use, ps_a_use, (float*)(b_use + (jr * ps_b_use)), rs_b_use,
-                cs_b_use, 0, 0, (c + jr * cs_c_use), rs_c, cs_c_use,
-                (void*)&alpha, (void*)&beta, post_op_list, post_ops_attr);
-        } else {
-            ((dlp_gemm_rowvar_f32)lcntx->kern_fun_ptr)(
-                m, nr0, k, (float*)a_use, rs_a_use, cs_a_use, ps_a_use,
-                (float*)(b_use + (jr * ps_b_use)), rs_b_use, cs_b_use,
-                (c + jr * cs_c_use), rs_c, cs_c_use, alpha, beta, post_op_list,
-                post_ops_attr);
+            // Post ops meta attributes.
+            post_ops_attr.post_op_c_i    = 0;
+            post_ops_attr.post_op_c_j    = jr;
+            post_ops_attr.rs_c_downscale = rs_c_downscale;
+
+            if (lcntx->dlp_kernel_hndl.kernel_base != NULL) {
+                dlp_execute_kernel(
+                    &(lcntx->dlp_kernel_hndl), m, nr0, k, (float*)a_use,
+                    rs_a_use, cs_a_use, ps_a_use,
+                    (float*)(b_use + (jr * ps_b_use)), rs_b_use, cs_b_use, 0, 0,
+                    (c + jr * cs_c_use), rs_c, cs_c_use, (void*)&alpha,
+                    (void*)&beta, post_op_list, post_ops_attr);
+            } else {
+                ((dlp_gemm_rowvar_f32)lcntx->kern_fun_ptr)(
+                    m, nr0, k, (float*)a_use, rs_a_use, cs_a_use, ps_a_use,
+                    (float*)(b_use + (jr * ps_b_use)), rs_b_use, cs_b_use,
+                    (c + jr * cs_c_use), rs_c, cs_c_use, alpha, beta,
+                    post_op_list, post_ops_attr);
+            }
         }
     }
 

--- a/src/frame/bindings/c_wrappers/capi_kernel_frame_wrappers.cc
+++ b/src/frame/bindings/c_wrappers/capi_kernel_frame_wrappers.cc
@@ -287,6 +287,16 @@ dlp_init_and_get_kernel_hndl(kernel_datatype_t     k_dtype,
     kernel_hndl->nr          = fastKI.nr;
     kernel_hndl->kDtype      = k_dtype;
     kernel_hndl->invokeRD    = fastKI.invokeRD;
+
+    // Check if the generated kernel has an internal N-loop
+    kernel_hndl->hasNLoop = false;
+    if (kernPtr.isValid()) {
+        auto* adapter =
+            dynamic_cast<jitKernelAdapter*>(kernPtr.getPtr());
+        if (adapter) {
+            kernel_hndl->hasNLoop = adapter->hasNLoop();
+        }
+    }
 }
 
 [[gnu::noinline]] static dlp::kernel_frame::kernelBaseRef
@@ -497,6 +507,61 @@ dlp_execute_kernel(dlp_kernel_hndl_t*    kernel_hndl,
         kernelBase* kB = static_cast<kernelBase*>(kernel_hndl->kernel_base);
         kB->operator()(std::addressof(gemmParamsIn));
     }
+
+    return;
+}
+
+[[gnu::aligned(64)]]
+#if defined(__clang__) && __clang_major__ >= 19
+__attribute__((always_inline))
+#endif
+void
+dlp_execute_kernel_nloop(dlp_kernel_hndl_t*    kernel_hndl,
+                         md_t                  m,
+                         md_t                  n,
+                         md_t                  k,
+                         void*                 A,
+                         md_t                  rs_a,
+                         md_t                  cs_a,
+                         md_t                  ps_a,
+                         void*                 B,
+                         md_t                  rs_b,
+                         md_t                  cs_b,
+                         md_t                  n_sub_updated,
+                         md_t                  jc_cur_loop_rem,
+                         void*                 C,
+                         md_t                  rs_c,
+                         md_t                  cs_c,
+                         void*                 alpha,
+                         void*                 beta,
+                         dlp_gemm_post_op*     post_ops_list,
+                         dlp_gemm_post_op_attr post_ops_attr)
+{
+    if (!kernel_hndl || !kernel_hndl->kernel_base) {
+        return;
+    }
+
+    gemmParams gemmParamsIn{ A,
+                             B,
+                             C,
+                             m,
+                             n,
+                             k,
+                             rs_a,
+                             cs_a,
+                             ps_a,
+                             rs_b,
+                             cs_b,
+                             rs_c,
+                             cs_c,
+                             alpha,
+                             beta,
+                             post_ops_list,
+                             post_ops_attr };
+    gemmParamsIn.useNLoop = true;
+
+    kernelBase* kB = static_cast<kernelBase*>(kernel_hndl->kernel_base);
+    kB->operator()(std::addressof(gemmParamsIn));
 
     return;
 }

--- a/src/include/bindings/c_wrappers/capi_kernel_frame_wrappers.h
+++ b/src/include/bindings/c_wrappers/capi_kernel_frame_wrappers.h
@@ -132,6 +132,7 @@ typedef struct
     md_t              nr;
     kernel_datatype_t kDtype;
     bool              invokeRD;
+    bool              hasNLoop;
 } dlp_kernel_hndl_t;
 
 typedef struct
@@ -224,6 +225,28 @@ dlp_execute_kernel(dlp_kernel_hndl_t*    kernel_hndl,
                    void*                 beta,
                    dlp_gemm_post_op*     post_ops_list,
                    dlp_gemm_post_op_attr post_ops_attr);
+
+void
+dlp_execute_kernel_nloop(dlp_kernel_hndl_t*    kernel_hndl,
+                         md_t                  m,
+                         md_t                  n,
+                         md_t                  k,
+                         void*                 A,
+                         md_t                  rs_a,
+                         md_t                  cs_a,
+                         md_t                  ps_a,
+                         void*                 B,
+                         md_t                  rs_b,
+                         md_t                  cs_b,
+                         md_t                  n_sub_updated,
+                         md_t                  jc_cur_loop_rem,
+                         void*                 C,
+                         md_t                  rs_c,
+                         md_t                  cs_c,
+                         void*                 alpha,
+                         void*                 beta,
+                         dlp_gemm_post_op*     post_ops_list,
+                         dlp_gemm_post_op_attr post_ops_attr);
 
 DLP_END_EXTERN_C
 

--- a/src/include/jit/jit_generator_base.hh
+++ b/src/include/jit/jit_generator_base.hh
@@ -100,6 +100,10 @@ class jitGeneratorBase
     {
         return kernels::kernelError::error;
     }
+
+    // Returns true if the generated kernel contains an internal N-loop,
+    // meaning a single kernel call handles the full N dimension.
+    virtual bool hasNLoop() const { return false; }
 };
 
 } // namespace dlp::jit

--- a/src/include/jit/jit_kernel_adapter.hh
+++ b/src/include/jit/jit_kernel_adapter.hh
@@ -123,6 +123,11 @@ class jitKernelAdapter : public kernels::kernelBase
 
     bool isJitGenerated() const { return mIsJitGenerated; }
 
+    bool hasNLoop() const
+    {
+        return mJitGen ? mJitGen->hasNLoop() : false;
+    }
+
     operator bool() const { return isJitGenerated(); }
 
     // kernelBase interface implementation

--- a/src/include/kernels/kernel_base.hh
+++ b/src/include/kernels/kernel_base.hh
@@ -98,6 +98,8 @@ struct gemmParams : public kernelParams
     dlp_gemm_post_op*     kernelOpsList;
     dlp_gemm_post_op_attr kernelOpsAttr;
 
+    bool useNLoop;
+
     gemmParams(void*                 A,
                void*                 B,
                void*                 C_acc,
@@ -146,6 +148,7 @@ struct gemmParams : public kernelParams
         , quantScale(nullptr)
         , kernelOpsList(kernelOpsList)
         , kernelOpsAttr(kernelOpsAttr)
+        , useNLoop(false)
     {
     }
 
@@ -178,6 +181,7 @@ struct gemmParams : public kernelParams
         , quantScale(other.quantScale)
         , kernelOpsList(other.kernelOpsList)
         , kernelOpsAttr(other.kernelOpsAttr)
+        , useNLoop(other.useNLoop)
     {
         std::copy(std::begin(other.maskF32), std::end(other.maskF32),
                   std::begin(maskF32));
@@ -218,6 +222,7 @@ struct gemmParams : public kernelParams
         , quantScale(other.quantScale)
         , kernelOpsList(other.kernelOpsList)
         , kernelOpsAttr(other.kernelOpsAttr)
+        , useNLoop(other.useNLoop)
     {
         std::copy(std::begin(other.maskF32), std::end(other.maskF32),
                   std::begin(maskF32));
@@ -262,6 +267,7 @@ struct gemmParams : public kernelParams
         quantScale    = other.quantScale;
         kernelOpsList = other.kernelOpsList;
         kernelOpsAttr = other.kernelOpsAttr;
+        useNLoop      = other.useNLoop;
         return *this;
     }
 
@@ -289,6 +295,7 @@ struct gemmParams : public kernelParams
         kLeftmask     = 0;
         quantScale    = nullptr;
         kernelOpsList = nullptr;
+        useNLoop      = false;
     }
 };
 

--- a/src/jit/amdzen/amdzen_generator.cc
+++ b/src/jit/amdzen/amdzen_generator.cc
@@ -724,18 +724,18 @@ jitAmdZenFP32::generateAllKernels(const dlp::jit::jitGeneratorContext& jI)
 
         // Additionally generate nloop kernel for tiny path.
         //
-        // Skip the nLoop kernel entirely when skinnyN bumped MR to a value
-        // larger than the default. The nLoop kernel uses NR=processBlockSize
+        // Skip the nloop kernel entirely when skinnyN bumped MR to a value
+        // larger than the default. The nloop kernel uses NR=processBlockSize
         // (e.g. 64 for ZMM F32), so its register budget is
         //   cReg = MR * (NR / numElemsPerReg)
         // which exceeds the 32-ZMM budget once MR > ~7 (with NR=64,
         // numElemsPerReg=16, cReg = MR*4). On the bumped-MR (MR=16) skinny-N
-        // path the nLoop allocateReg() therefore returns badKernelInfo, which
+        // path the nloop allocateReg() therefore returns badKernelInfo, which
         // would propagate via `goto cleanup` and wipe ALL kernel slots
         // (including the per-(mr,nr) variants that succeeded above),
         // leaving kernel_base=NULL and silently no-op'ing the GEMM. The
         // per-(mr,nr) dispatch path is what skinnyN was optimizing for, so
-        // dropping the nLoop tiny-path optimization here is safe.
+        // dropping the nloop tiny-path optimization here is safe.
         if (!jI.kI.skinnyN) {
             int processBlockSize = getProcessBlockSize();
             int nloopNumNRVariants = (processBlockSize / numElemsPerReg) + 1;
@@ -746,7 +746,7 @@ jitAmdZenFP32::generateAllKernels(const dlp::jit::jitGeneratorContext& jI)
                 0, 0, K_UNROLL, PREFETCH_C_DIST, c_downscale, 0, false, false,
                 false, (jI.kI).alphaScalingType, (jI.kI).betaScalingType,
                 kType);
-            nloopParams.nLoop = true;
+            nloopParams.nloop = true;
 
             for (std::size_t ii = 0; ii < (jI.kI).kOpsArrSize; ++ii) {
                 nloopParams.kernelOps.push_back((jI.kI).kOpsArr[ii]);
@@ -807,7 +807,7 @@ jitAmdZenFP32::generateAllKernels(const dlp::jit::jitGeneratorContext& jI)
                                             processBlockSize, false,
                                             processBlockSize);
         } else {
-            // skinnyN path: leave the nLoop kernel un-generated; the tiny-path
+            // skinnyN path: leave the nloop kernel un-generated; the tiny-path
             // framework code checks hasNLoop and falls back to the regular
             // per-(mr,nr) dispatch when hasNLoop is false.
             nloopKernelCodeBlock = nullptr;

--- a/src/jit/amdzen/amdzen_generator.cc
+++ b/src/jit/amdzen/amdzen_generator.cc
@@ -55,6 +55,7 @@ jitAmdZenFP32::jitAmdZenFP32()
     , kType(utils::kernelInstrType::none)
     , numElemsPerReg(1)     // Initializing with 1 to avoid div by zero
     , usingRDKernels(false) // Initialize to false
+    , hasNLoop_(false)      // Initialize to false
     , kernelSize(0)         // Initialize to 0, set when allocating kernels
 {
 }
@@ -65,6 +66,8 @@ jitAmdZenFP32::~jitAmdZenFP32()
     for (auto& block : kernelCodeBlocks) {
         block = nullptr;
     }
+    nloopCodeGenerator.reset();
+    nloopKernelCodeBlock = nullptr;
 }
 
 int
@@ -593,123 +596,222 @@ jitAmdZenFP32::generateAllKernels(const dlp::jit::jitGeneratorContext& jI)
         kernelSize = utils::JIT_KERNEL_SIZE; // Standard size for general GEMM
 
         // Initializing with default values.
-        utils::generatorParams params(
-            0, 0, K_UNROLL, PREFETCH_C_DIST, c_downscale, 0, false, false,
-            false, (jI.kI).alphaScalingType, (jI.kI).betaScalingType, kType);
+        {
+            utils::generatorParams params(
+                0, 0, K_UNROLL, PREFETCH_C_DIST, c_downscale, 0, false, false,
+                false, (jI.kI).alphaScalingType, (jI.kI).betaScalingType,
+                kType);
 
-        for (std::size_t ii = 0; ii < (jI.kI).kOpsArrSize; ++ii) {
-            // Copy the kernelOps from the kernelInfo to params
-            params.kernelOps.push_back((jI.kI).kOpsArr[ii]);
-        }
+            for (std::size_t ii = 0; ii < (jI.kI).kOpsArrSize; ++ii) {
+                // Copy the kernelOps from the kernelInfo to params
+                params.kernelOps.push_back((jI.kI).kOpsArr[ii]);
+            }
 
-        // Generate all kernels for the given MR and NR. Any per-variant
-        // generator failure (after passing the feasibility filter below)
-        // is fatal (goto cleanup): we want the existing fail-fast contract
-        // to hold, so we never call generateKernel() for an (mr, nr) pair
-        // we already know cannot fit.
-        //
-        // Feasibility filter: when the DE bumps MR (e.g. MR=16 for the
-        // skinny-N n<=16 override), the wider-NR variants (NR>=32) would
-        // exceed the register budget (cReg=MR*bReg, aReg = numRegs -
-        // cReg - bReg - maskVecReg, must have aReg >= 1 -- mirrors
-        // jitGEMMF32::allocateReg()). Skip those slots up front instead
-        // of relying on the per-variant generator to return badKernelInfo.
-        // The dispatcher only reaches the lt-mask kernel and the NR=16
-        // full kernel for n<=16, both of which always pass the filter.
-        const int kNumRegs =
-            (kType == utils::kernelInstrType::avx2_ymm_16_reg) ? 16 : 32;
-        for (iter_t mr = 0; mr < numMRVariants; mr++) {
-            for (iter_t nr = 0; nr < numNRVariants; nr++) {
-                params.MR    = mr == 0 ? MR : mr;
-                params.mLoop = mr == 0;
+            // Generate all kernels for the given MR and NR. Any per-variant
+            // generator failure (after passing the feasibility filter below)
+            // is fatal (goto cleanup): we want the existing fail-fast contract
+            // to hold, so we never call generateKernel() for an (mr, nr) pair
+            // we already know cannot fit.
+            //
+            // Feasibility filter: when the DE bumps MR (e.g. MR=16 for the
+            // skinny-N n<=16 override), the wider-NR variants (NR>=32) would
+            // exceed the register budget (cReg=MR*bReg, aReg = numRegs -
+            // cReg - bReg - maskVecReg, must have aReg >= 1 -- mirrors
+            // jitGEMMF32::allocateReg()). Skip those slots up front instead
+            // of relying on the per-variant generator to return badKernelInfo.
+            // The dispatcher only reaches the lt-mask kernel and the NR=16
+            // full kernel for n<=16, both of which always pass the filter.
+            const int kNumRegs =
+                (kType == utils::kernelInstrType::avx2_ymm_16_reg) ? 16 : 32;
+            for (iter_t mr = 0; mr < numMRVariants; mr++) {
+                for (iter_t nr = 0; nr < numNRVariants; nr++) {
+                    params.MR    = mr == 0 ? MR : mr;
+                    params.mLoop = mr == 0;
 
-                int correspondingMainFringe = 0;
-                deriveGEMMNRAndMaskUse(nr, params, correspondingMainFringe);
+                    int correspondingMainFringe = 0;
+                    deriveGEMMNRAndMaskUse(nr, params, correspondingMainFringe);
 
-                // Skinny-N override: when the DE has bumped MR via the
-                // n<=16 override (jI.kI.skinnyN), only the lt-numElems
-                // (nr=0) and the full numElems (nr=1) variants are ever
-                // dispatched at runtime. The wider NR slots (nr>=2:
-                // lt2x/2x/lt3x/3x/lt4x/4x) are unreachable AND would
-                // exceed the register budget at bumped MR -- skip them
-                // entirely so we don't waste codegen on dead kernels
-                // (and don't trigger badKernelInfo on infeasible ones).
-                if (jI.kI.skinnyN && nr >= 2) {
-                    continue;
-                }
-
-                // Pre-filter register-infeasible (MR, NR) variants. This
-                // mirrors jitGEMMF32<KType>::allocateReg(): bFullReg =
-                // NR / numElemsPerReg, bMaskReg = useMask ? numMaskRegs
-                // : 0, bReg = bFullReg + bMaskReg, cReg = MR * bReg.
-                // For AVX2 ymm, the mask consumes vector registers
-                // (maskVecReg = numMaskRegs); for AVX-512 the mask is in
-                // Opmask regs and does not draw from the vector budget.
-                {
-                    int bFullReg = params.NR / numElemsPerReg;
-                    int bMaskReg = params.useMask ? params.numMaskRegs : 0;
-                    int bReg     = bFullReg + bMaskReg;
-                    int cReg     = params.MR * bReg;
-                    int maskVecReg =
-                        (kType == utils::kernelInstrType::avx2_ymm_16_reg)
-                            ? bMaskReg
-                            : 0;
-                    if (kNumRegs - cReg - bReg - maskVecReg < 1) {
-                        // Slot stays nullptr (zero-initialized by
-                        // resize). The dispatcher never reaches it for
-                        // any DE-blessed shape that bumped MR.
+                    // Skinny-N override: when the DE has bumped MR via the
+                    // n<=16 override (jI.kI.skinnyN), only the lt-numElems
+                    // (nr=0) and the full numElems (nr=1) variants are ever
+                    // dispatched at runtime. The wider NR slots (nr>=2:
+                    // lt2x/2x/lt3x/3x/lt4x/4x) are unreachable AND would
+                    // exceed the register budget at bumped MR -- skip them
+                    // entirely so we don't waste codegen on dead kernels
+                    // (and don't trigger badKernelInfo on infeasible ones).
+                    if (jI.kI.skinnyN && nr >= 2) {
                         continue;
                     }
-                }
 
+                    // Pre-filter register-infeasible (MR, NR) variants. This
+                    // mirrors jitGEMMF32<KType>::allocateReg(): bFullReg =
+                    // NR / numElemsPerReg, bMaskReg = useMask ? numMaskRegs
+                    // : 0, bReg = bFullReg + bMaskReg, cReg = MR * bReg.
+                    // For AVX2 ymm, the mask consumes vector registers
+                    // (maskVecReg = numMaskRegs); for AVX-512 the mask is in
+                    // Opmask regs and does not draw from the vector budget.
+                    {
+                        int bFullReg = params.NR / numElemsPerReg;
+                        int bMaskReg = params.useMask ? params.numMaskRegs : 0;
+                        int bReg     = bFullReg + bMaskReg;
+                        int cReg     = params.MR * bReg;
+                        int maskVecReg =
+                            (kType == utils::kernelInstrType::avx2_ymm_16_reg)
+                                ? bMaskReg
+                                : 0;
+                        if (kNumRegs - cReg - bReg - maskVecReg < 1) {
+                            // Slot stays nullptr (zero-initialized by
+                            // resize). The dispatcher never reaches it for
+                            // any DE-blessed shape that bumped MR.
+                            continue;
+                        }
+                    }
+
+                    std::unique_ptr<Xbyak::CodeGenerator> gen;
+                    switch (kType) {
+                        case utils::kernelInstrType::avx512_zmm_32_reg: {
+                            auto g =
+                                std::make_unique<GEMMcodeGenerator::jitGEMMF32<
+                                    utils::kernelInstrType::avx512_zmm_32_reg>>(
+                                    kernelSize);
+                            err = g->generateKernel(params);
+                            gen = std::move(g);
+                            break;
+                        }
+                        case utils::kernelInstrType::avx512_ymm_32_reg: {
+                            auto g =
+                                std::make_unique<GEMMcodeGenerator::jitGEMMF32<
+                                    utils::kernelInstrType::avx512_ymm_32_reg>>(
+                                    kernelSize);
+                            err = g->generateKernel(params);
+                            gen = std::move(g);
+                            break;
+                        }
+                        case utils::kernelInstrType::avx2_ymm_16_reg: {
+                            auto g =
+                                std::make_unique<GEMMcodeGenerator::jitGEMMF32<
+                                    utils::kernelInstrType::avx2_ymm_16_reg>>(
+                                    kernelSize);
+                            err = g->generateKernel(params);
+                            gen = std::move(g);
+                            break;
+                        }
+                        default:
+                            err = dlp::jit::jitGeneratorError::error;
+                            break;
+                    }
+                    if (err != dlp::jit::jitGeneratorError::success) {
+                        goto cleanup;
+                    }
+                    // Must call ready() to readjust jump/branch targets with
+                    // respect to any new buffer created as part of AutoGrow
+                    // mode in Xbyak.
+                    gen->ready();
+                    kernelCodeBlocks[mr * numNRVariants + nr] =
+                        const_cast<void*>(
+                            static_cast<const void*>(gen->getCode()));
+                    codeGenerators.push_back(std::move(gen));
+
+                    // params.useMask=false implies a fringe or main kernel.
+                    // params.useMask=true implies a lt fringe or lt main kernel.
+                    DLP_ENABLE_JIT_DUMP_AND_MONITOR(
+                        kernelCodeBlocks[mr * numNRVariants + nr], kernelSize,
+                        "jit_kernel", params.MR, correspondingMainFringe,
+                        params.useMask, mr * numNRVariants + nr);
+                }
+            }
+        }
+
+        // Additionally generate nloop kernel for tiny path.
+        //
+        // Skip the nLoop kernel entirely when skinnyN bumped MR to a value
+        // larger than the default. The nLoop kernel uses NR=processBlockSize
+        // (e.g. 64 for ZMM F32), so its register budget is
+        //   cReg = MR * (NR / numElemsPerReg)
+        // which exceeds the 32-ZMM budget once MR > ~7 (with NR=64,
+        // numElemsPerReg=16, cReg = MR*4). On the bumped-MR (MR=16) skinny-N
+        // path the nLoop allocateReg() therefore returns badKernelInfo, which
+        // would propagate via `goto cleanup` and wipe ALL kernel slots
+        // (including the per-(mr,nr) variants that succeeded above),
+        // leaving kernel_base=NULL and silently no-op'ing the GEMM. The
+        // per-(mr,nr) dispatch path is what skinnyN was optimizing for, so
+        // dropping the nLoop tiny-path optimization here is safe.
+        if (!jI.kI.skinnyN) {
+            int processBlockSize = getProcessBlockSize();
+            int nloopNumNRVariants = (processBlockSize / numElemsPerReg) + 1;
+            size_t nloopKernelSize =
+                nloopNumNRVariants * MR * utils::JIT_KERNEL_SIZE;
+
+            utils::generatorParams nloopParams(
+                0, 0, K_UNROLL, PREFETCH_C_DIST, c_downscale, 0, false, false,
+                false, (jI.kI).alphaScalingType, (jI.kI).betaScalingType,
+                kType);
+            nloopParams.nLoop = true;
+
+            for (std::size_t ii = 0; ii < (jI.kI).kOpsArrSize; ++ii) {
+                nloopParams.kernelOps.push_back((jI.kI).kOpsArr[ii]);
+            }
+
+            nloopParams.MR = MR;
+            nloopParams.NR = processBlockSize;
+
+            {
                 std::unique_ptr<Xbyak::CodeGenerator> gen;
                 switch (kType) {
                     case utils::kernelInstrType::avx512_zmm_32_reg: {
                         auto g = std::make_unique<GEMMcodeGenerator::jitGEMMF32<
                             utils::kernelInstrType::avx512_zmm_32_reg>>(
-                            kernelSize);
-                        err = g->generateKernel(params);
+                            nloopKernelSize);
+                        err = g->generateKernel(nloopParams);
                         gen = std::move(g);
                         break;
                     }
                     case utils::kernelInstrType::avx512_ymm_32_reg: {
                         auto g = std::make_unique<GEMMcodeGenerator::jitGEMMF32<
                             utils::kernelInstrType::avx512_ymm_32_reg>>(
-                            kernelSize);
-                        err = g->generateKernel(params);
+                            nloopKernelSize);
+                        err = g->generateKernel(nloopParams);
                         gen = std::move(g);
                         break;
                     }
                     case utils::kernelInstrType::avx2_ymm_16_reg: {
                         auto g = std::make_unique<GEMMcodeGenerator::jitGEMMF32<
                             utils::kernelInstrType::avx2_ymm_16_reg>>(
-                            kernelSize);
-                        err = g->generateKernel(params);
+                            nloopKernelSize);
+                        err = g->generateKernel(nloopParams);
                         gen = std::move(g);
                         break;
                     }
-                    default:
+                    default: {
                         err = dlp::jit::jitGeneratorError::error;
                         break;
+                    }
                 }
                 if (err != dlp::jit::jitGeneratorError::success) {
                     goto cleanup;
                 }
-                // Must call ready() to readjust jump/branch targets with
-                // respect to any new buffer created as part of AutoGrow mode
-                // in Xbyak.
                 gen->ready();
-                kernelCodeBlocks[mr * numNRVariants + nr] =
+                nloopKernelCodeBlock =
                     const_cast<void*>(static_cast<const void*>(gen->getCode()));
-                codeGenerators.push_back(std::move(gen));
-
-                // params.useMask=false implies a fringe or main kernel.
-                // params.useMask=true implies a lt fringe or lt main kernel.
-                DLP_ENABLE_JIT_DUMP_AND_MONITOR(
-                    kernelCodeBlocks[mr * numNRVariants + nr], kernelSize,
-                    "jit_kernel", params.MR, correspondingMainFringe,
-                    params.useMask, mr * numNRVariants + nr);
+                nloopCodeGenerator = std::move(gen);
             }
+
+            // Disable nloop when processBlockSize < NR (avx512_ymm) because
+            // the B advancement formula (csB * processBlockSize) produces
+            // incorrect strides for packed B in NR-wide panels.
+            hasNLoop_ = (processBlockSize == NR);
+
+            DLP_ENABLE_JIT_DUMP_AND_MONITOR(nloopKernelCodeBlock,
+                                            nloopKernelSize,
+                                            "jit_kernel_nloop", MR,
+                                            processBlockSize, false,
+                                            processBlockSize);
+        } else {
+            // skinnyN path: leave the nLoop kernel un-generated; the tiny-path
+            // framework code checks hasNLoop and falls back to the regular
+            // per-(mr,nr) dispatch when hasNLoop is false.
+            nloopKernelCodeBlock = nullptr;
+            hasNLoop_            = false;
         }
     }
 
@@ -720,6 +822,8 @@ cleanup:
     for (auto& block : kernelCodeBlocks) {
         block = nullptr;
     }
+    nloopCodeGenerator.reset();
+    nloopKernelCodeBlock = nullptr;
     return err;
 }
 
@@ -1028,120 +1132,141 @@ jitAmdZenFP32::executeKernel(dlp::kernels::kernelParams* _params)
             return executeKernelRD(_params);
         }
 
-        // Note: It is expected the generateAllKernels is called before
-        // calling this function.
         auto params = static_cast<dlp::kernels::gemmParams*>(_params);
 
         int processBlockSize = getProcessBlockSize();
-        // Since JR loop is in framework, the 'n' dimension passed to this
-        // function is always <= NR.
-        int mFullPieces    = params->m / MR;
-        int mPartialPieces = params->m % MR;
 
-        params->kIterBP = params->k / K_UNROLL;
-        params->kLeft   = params->k % K_UNROLL;
+        if (hasNLoop_ && params->useNLoop) {
+            // nloop path: single JIT kernel handles M, N, and K loops
+            params->mIter = params->m / MR;
+            params->mLeft = params->m % MR;
+            params->nIter = params->n / processBlockSize;
+            params->nLeft = params->n % processBlockSize;
+            params->kIterBP = params->k / K_UNROLL;
+            params->kLeft   = params->k % K_UNROLL;
 
-        float* aPtr = static_cast<float*>(params->a);
-        float* bPtr = static_cast<float*>(params->b);
-        float* cPtr = static_cast<float*>(params->c);
-        // Initialize pointers to A and B
-        float* c_jr = cPtr;
-        float* c_ir = cPtr;
+            md_t nRemainder = params->n % numElemsPerReg;
+            if (nRemainder > 0) {
+                setMaskForGEMMLtFringe(params, nRemainder);
+            }
 
-        md_t n = params->n;
-        md_t m = params->m;
-        md_t k = params->k;
+            auto kernel = reinterpret_cast<utils::jit_kernel>(
+                nloopKernelCodeBlock);
+            kernel(params);
+        } else {
+            // Note: It is expected the generateAllKernels is called before
+            // calling this function.
 
-        md_t og_post_op_c_i = (params->kernelOpsAttr).post_op_c_i;
+            // Since JR loop is in framework, the 'n' dimension passed to this
+            // function is always <= NR.
+            int mFullPieces    = params->m / MR;
+            int mPartialPieces = params->m % MR;
 
-        // OVERVIEW:
-        // This unified approach works for all kernel types (ZMM, YMM, AVX2).
-        // The key insight is that all architectures follow the same pattern:
-        // process elements in blocks, decompose fringe blocks into complete
-        // registers + remainder, then execute appropriate kernels.
-        //
-        // EXECUTION LOGIC:
-        // 1. Process elements in chunks of 'processBlockSize':
-        //    - ZMM: processBlockSize = 64 (full NR), numElemsPerReg = 16
-        //    - YMM: processBlockSize = 32 (NR/2), numElemsPerReg = 8
-        //
-        // 2. For each chunk, decompose into complete SIMD registers +
-        // remainder:
-        //    - Complete registers: Use kernel_idx = nFullpieces (no masking)
-        //    - Remainder elements: Use kernel_idx = 0 (mask kernel with
-        //    masking)
-        //
-        // 3. Execute kernels in sequence: complete registers first, then
-        // remainder
-        //
-        // EXAMPLE WALKTHROUGH (n=15 with YMM):
-        // - processBlockSize=32, numElemsPerReg=8
-        // - Iteration 1: nBlockSize = min(15, 32) = 15
-        //   - nFullpieces = 15/8 = 1  -> Execute kernel_idx=1 for 8 elements
-        //   (no mask)
-        //   - nRemainder = 15%8 = 7   -> Execute kernel_idx=0 for 7 elements
-        //   (with mask)
-        //   - Total processed: 8 + 7 = 15, n becomes 0, loop exits
-        //
-        // EXAMPLE WALKTHROUGH (n=95 with YMM):
-        // - Iteration 1: nBlockSize = min(95, 32) = 32
-        //   - nFullpieces = 32/8 = 4  -> Execute kernel_idx=4 for 32 elements
-        //   (no mask)
-        //   - nRemainder = 32%8 = 0   -> No remainder processing
-        //   - Processed: 32, n becomes 63
-        // - Iteration 2: nBlockSize = min(63, 32) = 32 -> Process 32 more
-        // elements
-        //   - Processed: 32, n becomes 31
-        // - Iteration 3: nBlockSize = min(31, 32) = 31
-        //   - nFullpieces = 31/8 = 3  -> Execute kernel_idx=3 for 24 elements
-        //   (no mask)
-        //   - nRemainder = 31%8 = 7   -> Execute kernel_idx=0 for 7 elements
-        //   (with mask)
-        //   - Processed: 24 + 7 = 31, n becomes 0, loop exits
+            params->kIterBP = params->k / K_UNROLL;
+            params->kLeft   = params->k % K_UNROLL;
 
-        while (n > 0) {
-            // Its expected that every NR value is multiple of numElemsPerReg.
-            int nBlockSize  = (n >= processBlockSize) ? processBlockSize : n;
-            int nFullpieces = nBlockSize / numElemsPerReg;
-            int nRemainder  = ((nFullpieces - termNRFringeRegCount) >= 0)
-                                  ? (nBlockSize - (nFullpieces * numElemsPerReg))
-                                  : nBlockSize;
+            float* aPtr = static_cast<float*>(params->a);
+            float* bPtr = static_cast<float*>(params->b);
+            float* cPtr = static_cast<float*>(params->c);
+            // Initialize pointers to A and B
+            float* c_jr = cPtr;
+            float* c_ir = cPtr;
 
-            if (isGenLtKrnlForAvailFullKrnl) {
-                // Case where we generate both "==" and "<" kernels for
-                // each multiple of numElemsPerReg including "0".
-                int idBase       = ((nFullpieces - termNRFringeRegCount) >= 0)
-                                       ? (nFullpieces - termNRFringeRegCount)
-                                       : -1;
-                int kernel_n_idx = (2 * (idBase + 1)) - 1;
-                if (nRemainder > 0) {
-                    setMaskForGEMMLtFringe(params, nRemainder);
-                    kernel_n_idx += 1;
-                }
+            md_t n = params->n;
+            md_t m = params->m;
+            md_t k = params->k;
 
-                int elementsToProcess = nBlockSize;
-                executeGEMMMLoop(params, mFullPieces, mPartialPieces,
-                                 kernel_n_idx, elementsToProcess, n, &c_jr,
-                                 og_post_op_c_i, aPtr);
-            } else {
-                // Case where we generate "==" kernels for each multiple
-                // of numElemsPerReg including and 1 "<" kernel for the
-                // smallest multiple of numElemsPerReg, "0".
-                if (nFullpieces >= termNRFringeRegCount) {
-                    int kernel_n_idx = nFullpieces - termNRFringeRegCount + 1;
-                    int elementsToProcess = nFullpieces * numElemsPerReg;
+            md_t og_post_op_c_i = (params->kernelOpsAttr).post_op_c_i;
+
+            // OVERVIEW:
+            // This unified approach works for all kernel types (ZMM, YMM, AVX2).
+            // The key insight is that all architectures follow the same pattern:
+            // process elements in blocks, decompose fringe blocks into complete
+            // registers + remainder, then execute appropriate kernels.
+            //
+            // EXECUTION LOGIC:
+            // 1. Process elements in chunks of 'processBlockSize':
+            //    - ZMM: processBlockSize = 64 (full NR), numElemsPerReg = 16
+            //    - YMM: processBlockSize = 32 (NR/2), numElemsPerReg = 8
+            //
+            // 2. For each chunk, decompose into complete SIMD registers +
+            // remainder:
+            //    - Complete registers: Use kernel_idx = nFullpieces (no masking)
+            //    - Remainder elements: Use kernel_idx = 0 (mask kernel with
+            //    masking)
+            //
+            // 3. Execute kernels in sequence: complete registers first, then
+            // remainder
+            //
+            // EXAMPLE WALKTHROUGH (n=15 with YMM):
+            // - processBlockSize=32, numElemsPerReg=8
+            // - Iteration 1: nBlockSize = min(15, 32) = 15
+            //   - nFullpieces = 15/8 = 1  -> Execute kernel_idx=1 for 8 elements
+            //   (no mask)
+            //   - nRemainder = 15%8 = 7   -> Execute kernel_idx=0 for 7 elements
+            //   (with mask)
+            //   - Total processed: 8 + 7 = 15, n becomes 0, loop exits
+            //
+            // EXAMPLE WALKTHROUGH (n=95 with YMM):
+            // - Iteration 1: nBlockSize = min(95, 32) = 32
+            //   - nFullpieces = 32/8 = 4  -> Execute kernel_idx=4 for 32 elements
+            //   (no mask)
+            //   - nRemainder = 32%8 = 0   -> No remainder processing
+            //   - Processed: 32, n becomes 63
+            // - Iteration 2: nBlockSize = min(63, 32) = 32 -> Process 32 more
+            // elements
+            //   - Processed: 32, n becomes 31
+            // - Iteration 3: nBlockSize = min(31, 32) = 31
+            //   - nFullpieces = 31/8 = 3  -> Execute kernel_idx=3 for 24 elements
+            //   (no mask)
+            //   - nRemainder = 31%8 = 7   -> Execute kernel_idx=0 for 7 elements
+            //   (with mask)
+            //   - Processed: 24 + 7 = 31, n becomes 0, loop exits
+
+            while (n > 0) {
+                // Its expected that every NR value is multiple of numElemsPerReg.
+                int nBlockSize  = (n >= processBlockSize) ? processBlockSize : n;
+                int nFullpieces = nBlockSize / numElemsPerReg;
+                int nRemainder  = ((nFullpieces - termNRFringeRegCount) >= 0)
+                                      ? (nBlockSize - (nFullpieces * numElemsPerReg))
+                                      : nBlockSize;
+
+                if (isGenLtKrnlForAvailFullKrnl) {
+                    // Case where we generate both "==" and "<" kernels for
+                    // each multiple of numElemsPerReg including "0".
+                    int idBase       = ((nFullpieces - termNRFringeRegCount) >= 0)
+                                           ? (nFullpieces - termNRFringeRegCount)
+                                           : -1;
+                    int kernel_n_idx = (2 * (idBase + 1)) - 1;
+                    if (nRemainder > 0) {
+                        setMaskForGEMMLtFringe(params, nRemainder);
+                        kernel_n_idx += 1;
+                    }
+
+                    int elementsToProcess = nBlockSize;
                     executeGEMMMLoop(params, mFullPieces, mPartialPieces,
                                      kernel_n_idx, elementsToProcess, n, &c_jr,
                                      og_post_op_c_i, aPtr);
-                }
+                } else {
+                    // Case where we generate "==" kernels for each multiple
+                    // of numElemsPerReg including and 1 "<" kernel for the
+                    // smallest multiple of numElemsPerReg, "0".
+                    if (nFullpieces >= termNRFringeRegCount) {
+                        int kernel_n_idx = nFullpieces - termNRFringeRegCount + 1;
+                        int elementsToProcess = nFullpieces * numElemsPerReg;
+                        executeGEMMMLoop(params, mFullPieces, mPartialPieces,
+                                         kernel_n_idx, elementsToProcess, n,
+                                         &c_jr, og_post_op_c_i, aPtr);
+                    }
 
-                // Process remainder with mask (if any)
-                if (nRemainder > 0) {
-                    setMaskForGEMMLtFringe(params, nRemainder);
-                    int kernel_n_idx = 0; // Use lt mask kernel for nRemainder.
-                    executeGEMMMLoop(params, mFullPieces, mPartialPieces,
-                                     kernel_n_idx, nRemainder, n, &c_jr,
-                                     og_post_op_c_i, aPtr);
+                    // Process remainder with mask (if any)
+                    if (nRemainder > 0) {
+                        setMaskForGEMMLtFringe(params, nRemainder);
+                        int kernel_n_idx = 0; // Use lt mask kernel for nRemainder.
+                        executeGEMMMLoop(params, mFullPieces, mPartialPieces,
+                                         kernel_n_idx, nRemainder, n, &c_jr,
+                                         og_post_op_c_i, aPtr);
+                    }
                 }
             }
         }

--- a/src/jit/amdzen/amdzen_generator.hh
+++ b/src/jit/amdzen/amdzen_generator.hh
@@ -57,6 +57,7 @@ class jitAmdZenFP32 : public dlp::jit::jitGeneratorBase
     bool isGenLtKrnlForAvailFullKrnl;
 
     bool usingRDKernels; // Flag to track if RD kernels were generated
+    bool hasNLoop_;      // Flag to track if nloop kernel was generated
 
     md_t               numKernelVariants;
     md_t               K_UNROLL, PREFETCH_C_DIST;
@@ -64,6 +65,9 @@ class jitAmdZenFP32 : public dlp::jit::jitGeneratorBase
     std::vector<void*> kernelCodeBlocks;
     size_t             kernelSize; // Size of each kernel variant in bytes
     std::vector<std::unique_ptr<Xbyak::CodeGenerator>> codeGenerators;
+
+    void* nloopKernelCodeBlock = nullptr;
+    std::unique_ptr<Xbyak::CodeGenerator> nloopCodeGenerator;
 
     void setGeneratorKernelMetaInfo(
         dlp::kernel_frame::kernelInstrPreference kInstPref);
@@ -174,6 +178,8 @@ class jitAmdZenFP32 : public dlp::jit::jitGeneratorBase
 
     dlp::kernels::kernelError executeKernelRD(
         dlp::kernels::kernelParams* _params);
+
+    bool hasNLoop() const override { return hasNLoop_; }
 
     std::unique_ptr<jitGeneratorBase> clone() override
     {

--- a/src/jit/amdzen/f32_gemm_generator.cc
+++ b/src/jit/amdzen/f32_gemm_generator.cc
@@ -1411,8 +1411,8 @@ jitGEMMF32<KType>::generateKernel(utils::generatorParams& params)
         return generateKernelK1(params);
     }
 
-    // Check if this is an nLoop kernel (M and N loops inside JIT)
-    if (params.nLoop) {
+    // Check if this is an nloop kernel (M and N loops inside JIT)
+    if (params.nloop) {
         return generateKernel_IR_JR_General(params);
     }
 

--- a/src/jit/amdzen/f32_gemm_generator.cc
+++ b/src/jit/amdzen/f32_gemm_generator.cc
@@ -1411,6 +1411,11 @@ jitGEMMF32<KType>::generateKernel(utils::generatorParams& params)
         return generateKernelK1(params);
     }
 
+    // Check if this is an nLoop kernel (M and N loops inside JIT)
+    if (params.nLoop) {
+        return generateKernel_IR_JR_General(params);
+    }
+
     MR          = params.MR;
     currentMR   = MR;
     NR          = params.NR;
@@ -2078,6 +2083,386 @@ jitGEMMF32<KType>::generateKernel_IR_JR(utils::generatorParams& params)
     }
 
     L(done_k1);
+
+    vzeroupper();
+
+    return dlp::jit::jitGeneratorError::success;
+}
+
+// Generate kernel with M-outer, N-middle, K-inner loops all inside the JIT
+// kernel. This avoids per-NR-strip function call overhead for the general
+// GEMM (K>1) case on the tiny path.
+template<utils::kernelInstrType KType>
+dlp::jit::jitGeneratorError
+jitGEMMF32<KType>::generateKernel_IR_JR_General(utils::generatorParams& params)
+{
+    MR          = params.MR;
+    NR          = params.NR;
+    c_downscale = params.c_downscale;
+
+    // Setting params.mLoop to false since we handle M-loop ourselves
+    params.mLoop = false;
+
+    // Allocate 48 bytes of local stack space for BF16 conversion constants
+    Xbyak::util::StackFrame stackFrame(
+        this, 1, 12 | Xbyak::util::UseRBPAsFramePointer, 48);
+    initializeStackFrame(stackFrame);
+    regNiter = regTmp2;
+    regNLeft = regKIter;
+    initializeParameters(true);
+
+    // Create kernel ops handler once for the entire kernel
+    std::unique_ptr<gen::kernelOpsHandler<KType>> kernelOpsHandlerPtr;
+    if (!params.kernelOps.empty()) {
+        kernelOpsHandlerPtr =
+            std::make_unique<gen::kernelOpsHandler<KType>>(this);
+    }
+
+    numNRVariants = NR / numElemsPerReg + 1; // +1 for the mask variant
+    numMRVariants = MR;
+
+    // Initialize labels
+    std::vector<Xbyak::Label>              m_labels;
+    Xbyak::Label                           done_all;
+    std::vector<Xbyak::Label>              NIterLoop;
+    Xbyak::Label                           MIterLoop;
+    std::vector<Xbyak::Label>              done_nVariants;
+    Xbyak::Label                           considerMLeft;
+    std::vector<Xbyak::Label>              considerNLeft;
+    std::vector<std::vector<Xbyak::Label>> skip_NR;
+
+    m_labels.resize(numMRVariants);
+    label_store_result_k1.resize(numMRVariants);
+    skip_NR.resize(numMRVariants);
+    considerNLeft.resize(numMRVariants);
+    done_nVariants.resize(numMRVariants);
+    NIterLoop.resize(numMRVariants);
+
+    // M-outer loop, N-middle loop, K-inner loop
+    for (int mr = MR; mr > 0; mr--) {
+
+        label_store_result_k1[mr - 1].resize(numNRVariants);
+        skip_NR[mr - 1].resize(numNRVariants);
+
+        bool isMainMRVariant = mr == MR;
+
+        currentMR = mr;
+
+        L(m_labels[mr - 1]);
+
+        if (isMainMRVariant) {
+            mov(regMiter,
+                ptr[stackPtr + offsetof(dlp::kernels::gemmParams, mIter)]);
+            test(regMiter, regMiter);
+            je(considerMLeft, T_NEAR);
+            L(MIterLoop);
+        }
+
+        // Save N-loop state on stack
+        mov(regTmp1,
+            ptr[stackPtr + offsetof(dlp::kernels::gemmParams, kernelOpsAttr)
+                + offsetof(dlp_gemm_post_op_attr, post_op_c_j)]);
+        push(regTmp1);
+        mov(regNiter,
+            ptr[stackPtr + offsetof(dlp::kernels::gemmParams, nIter)]);
+        push(regNiter);
+        mov(regNLeft,
+            ptr[stackPtr + offsetof(dlp::kernels::gemmParams, nLeft)]);
+        push(regNLeft);
+        mov(regBptr, ptr[stackPtr + offsetof(dlp::kernels::gemmParams, b)]);
+        push(regBptr);
+
+        // N-middle loop: generate all NR variants
+        for (currentNRIdx = numNRVariants - 1; currentNRIdx >= 0;
+             currentNRIdx--) {
+
+            currentNR = currentNRIdx * numElemsPerReg;
+            bool isMainNRVariant = currentNRIdx == numNRVariants - 1;
+
+            if (isMainNRVariant) {
+                mov(regNiter,
+                    ptr[stackPtr + offsetof(dlp::kernels::gemmParams, nIter)]);
+                test(regNiter, regNiter);
+                je(considerNLeft[mr - 1], T_NEAR);
+                L(NIterLoop[mr - 1]);
+            } else {
+                cmp(regNLeft, currentNR);
+                jl(skip_NR[mr - 1][currentNRIdx], T_NEAR);
+            }
+
+            // Reload A ptr for this row
+            mov(regAPtr, ptr[stackPtr + offsetof(dlp::kernels::gemmParams, a)]);
+
+            // Reload regCsA since regTmp3 (aliased to regCsA) may have been
+            // clobbered by C/B pointer advancement in a previous NR sub-block
+            // or M iteration.
+            mov(regCsA, ptr[stackPtr + offsetof(dlp::kernels::gemmParams, csA)]);
+            lea(regCsA, ptr[regCsA * sizeof(float)]);
+
+            // Store nLeft value to n for transpose generator
+            mov(ptr[stackPtr + offsetof(dlp::kernels::gemmParams, n)],
+                regNLeft);
+
+            useMask     = currentNRIdx == 0;
+            numMaskRegs = useMask ? 1 : 0;
+            RETURN_IF_ERROR(allocateMaskRegisters());
+            loadMasks();
+
+            RETURN_IF_ERROR(allocateReg());
+
+            // --- K-inner loop body (adapted from generateIrLoop) ---
+            inLocalLabel();
+
+            mov(regTmpAptr, regAPtr);
+            mov(regBptr,
+                ptr[stackPtr + offsetof(dlp::kernels::gemmParams, b)]);
+
+            // Zero out accumulators
+            regInit();
+
+            // K main loop
+            mov(regKIter,
+                ptr[stackPtr + offsetof(dlp::kernels::gemmParams, kIterBP)]);
+            test(regKIter, regKIter);
+            je(".BCONSIDKLEFT", T_NEAR);
+
+            L(".BLOOPKITER");
+            RETURN_IF_ERROR(kernelUnroll(params.K_UNROLL));
+            dec(regKIter);
+            jne(".BLOOPKITER", T_NEAR);
+
+            L(".BCONSIDKLEFT");
+            mov(regKIter,
+                ptr[stackPtr + offsetof(dlp::kernels::gemmParams, kLeft)]);
+            test(regKIter, regKIter);
+            je(".BPOSTACCUM", T_NEAR);
+
+            RETURN_IF_ERROR(kernelUnroll(1));
+
+            L(".BPOSTACCUM");
+
+            if (params.alphaScalingType == dlp::kernel_frame::scalingType::one) {
+                // skip alpha scaling if alpha is 1
+            } else {
+                RETURN_IF_ERROR(scaleAlpha());
+            }
+
+            // Check if is_last_k is set
+            mov(regTmp1,
+                ptr[stackPtr + offsetof(dlp::kernels::gemmParams, kernelOpsAttr)
+                    + offsetof(dlp_gemm_post_op_attr, is_last_k)]);
+            test(regTmp1, regTmp1);
+            je(label_store_result_k1[currentMR - 1][currentNRIdx], T_NEAR);
+
+            // Post-ops path (when is_last_k is set)
+            if (!params.kernelOps.empty()) {
+                using VecPoolType =
+                    utils::registerPool<typename Traits::RegType,
+                                        Traits::numRegs>;
+                using MaskPoolType =
+                    utils::registerPool<Xbyak::Opmask, Traits::numMaskRegs>;
+
+                if (params.betaScalingType
+                    == dlp::kernel_frame::scalingType::zero) {
+                    // skip beta scaling if beta is 0
+                } else {
+                    RETURN_IF_ERROR(scaleBeta());
+                }
+
+                VecPoolType vecPool;
+                vecPool.addPreserve(bRegIdx, cRegIdx - bRegIdx);
+                if constexpr (KType
+                              == utils::kernelInstrType::avx2_ymm_16_reg) {
+                    if (useMask && maskVecReg > 0) {
+                        vecPool.addPreserve(maskRegIdx);
+                    }
+                }
+                vecPool.setAccumulators(cRegIdx, cReg);
+                RETURN_IF_ERROR(vecPool.init(this, Traits::regBytes));
+
+                MaskPoolType maskPool;
+                maskPool.addPreserve(utils::MASK_START_IDX,
+                                     useMask ? numMaskRegs : 0);
+                RETURN_IF_ERROR(maskPool.init(this,
+                                              utils::maskSaveWidth<KType>(),
+                                              Traits::reservedMaskBits));
+
+                int maskOffset;
+                if constexpr (KType
+                              == utils::kernelInstrType::avx2_ymm_16_reg) {
+                    maskOffset =
+                        useMask
+                            ? offsetof(dlp::kernels::gemmParams, maskArray)
+                            : -1;
+                } else if constexpr (KType
+                                     == utils::kernelInstrType::
+                                         avx512_ymm_32_reg) {
+                    maskOffset =
+                        useMask
+                            ? offsetof(dlp::kernels::gemmParams, maskF32_8[0])
+                            : -1;
+                } else {
+                    maskOffset =
+                        useMask
+                            ? offsetof(dlp::kernels::gemmParams, maskF32[0])
+                            : -1;
+                }
+
+                RETURN_IF_ERROR((kernelOpsHandlerPtr->generateKernelOps(
+                    params.kernelOps, stackPtr, dlp::jit::jitAlgoType::gemm,
+                    currentMR, currentNR, useMask, numMaskRegs, cRegIdx,
+                    cReg, vecPool, maskPool, maskOffset)));
+
+                RETURN_IF_ERROR(storeResult(false, false));
+                jmp(".AfterStore", T_NEAR);
+            }
+
+            // Store result path (when is_last_k is NOT set, or no post-ops)
+            L(label_store_result_k1[currentMR - 1][currentNRIdx]);
+
+            {
+                bool decoupleBeta = (c_downscale < DLP_F32);
+                if constexpr (KType
+                              == utils::kernelInstrType::avx512_zmm_32_reg) {
+                    decoupleBeta = decoupleBeta || (bReg == 1);
+                }
+
+                if (decoupleBeta) {
+                    if (params.betaScalingType
+                        != dlp::kernel_frame::scalingType::zero) {
+                        RETURN_IF_ERROR(scaleBeta());
+                    }
+                    RETURN_IF_ERROR(storeResult(false, false));
+                } else if (params.betaScalingType
+                           == dlp::kernel_frame::scalingType::zero) {
+                    RETURN_IF_ERROR(storeResult(false, false));
+                } else {
+                    RETURN_IF_ERROR(storeResult(true, false));
+                }
+            }
+
+            L(".AfterStore");
+
+            outLocalLabel();
+            // --- End K-inner loop body ---
+
+            // Advance B pointer to next NR sub-block.
+            // For the main NR variant (panel-to-panel jump), advance by
+            // csB * currentNR * sizeof(float) where csB holds ps_b_use (=k
+            // for packed B). This gives NR*k*sizeof(float) = one full panel.
+            // For fringe NR variants (within-panel jump), advance by just
+            // currentNR * sizeof(float) since columns within a packed panel
+            // are contiguous.
+            mov(regTmp1, ptr[stackPtr + offsetof(dlp::kernels::gemmParams, b)]);
+            if (isMainNRVariant) {
+                mov(regTmp3,
+                    ptr[stackPtr + offsetof(dlp::kernels::gemmParams, csB)]);
+                imul(regTmp3, regTmp3,
+                     static_cast<int>(currentNR * sizeof(float)));
+                add(regTmp1, regTmp3);
+            } else {
+                add(regTmp1, currentNR * sizeof(float));
+            }
+            mov(ptr[stackPtr + offsetof(dlp::kernels::gemmParams, b)], regTmp1);
+
+            // Advance C by currentNR * csC
+            mov(regTmp3,
+                ptr[stackPtr + offsetof(dlp::kernels::gemmParams, csC)]);
+            lea(regTmp3, ptr[regTmp3 * sizeof(float)]);
+            moveCPtr(regCPtr, regTmp3, currentNR);
+
+            // Advance post_op_c_j by currentNR
+            mov(regTmp1,
+                ptr[stackPtr + offsetof(dlp::kernels::gemmParams, kernelOpsAttr)
+                    + offsetof(dlp_gemm_post_op_attr, post_op_c_j)]);
+            add(regTmp1, currentNR);
+            mov(ptr[stackPtr + offsetof(dlp::kernels::gemmParams, kernelOpsAttr)
+                    + offsetof(dlp_gemm_post_op_attr, post_op_c_j)],
+                regTmp1);
+
+            if (isMainNRVariant) {
+                mov(regNiter,
+                    ptr[stackPtr + offsetof(dlp::kernels::gemmParams, nIter)]);
+                dec(regNiter);
+                mov(ptr[stackPtr + offsetof(dlp::kernels::gemmParams, nIter)],
+                    regNiter);
+                jnz(NIterLoop[mr - 1], T_NEAR);
+
+                L(considerNLeft[mr - 1]);
+                mov(regNLeft,
+                    ptr[stackPtr + offsetof(dlp::kernels::gemmParams, nLeft)]);
+                test(regNLeft, regNLeft);
+                je(done_nVariants[mr - 1], T_NEAR);
+            } else {
+                mov(regNLeft,
+                    ptr[stackPtr + offsetof(dlp::kernels::gemmParams, nLeft)]);
+                sub(regNLeft, currentNR);
+                mov(ptr[stackPtr + offsetof(dlp::kernels::gemmParams, nLeft)],
+                    regNLeft);
+                test(regNLeft, regNLeft);
+                jz(done_nVariants[mr - 1], T_NEAR);
+                L(skip_NR[mr - 1][currentNRIdx]);
+            }
+        }
+
+        // Restore N-loop state
+        L(done_nVariants[mr - 1]);
+        pop(regBptr);
+        mov(ptr[stackPtr + offsetof(dlp::kernels::gemmParams, b)], regBptr);
+        pop(regNLeft);
+        mov(ptr[stackPtr + offsetof(dlp::kernels::gemmParams, nLeft)],
+            regNLeft);
+        pop(regNiter);
+        mov(ptr[stackPtr + offsetof(dlp::kernels::gemmParams, nIter)],
+            regNiter);
+        pop(regTmp1);
+        mov(ptr[stackPtr + offsetof(dlp::kernels::gemmParams, kernelOpsAttr)
+                + offsetof(dlp_gemm_post_op_attr, post_op_c_j)],
+            regTmp1);
+
+        if (isMainMRVariant) {
+            // Advance A by psA
+            mov(regTmp1,
+                ptr[stackPtr + offsetof(dlp::kernels::gemmParams, psA)]);
+            lea(regTmp1, ptr[regTmp1 * sizeof(float)]);
+            lea(regAPtr, ptr[regAPtr + regTmp1]);
+            mov(ptr[stackPtr + offsetof(dlp::kernels::gemmParams, a)], regAPtr);
+
+            // Update post_op_c_i
+            mov(regTmp1,
+                ptr[stackPtr + offsetof(dlp::kernels::gemmParams, kernelOpsAttr)
+                    + offsetof(dlp_gemm_post_op_attr, post_op_c_i)]);
+            add(regTmp1, currentMR);
+            mov(ptr[stackPtr + offsetof(dlp::kernels::gemmParams, kernelOpsAttr)
+                    + offsetof(dlp_gemm_post_op_attr, post_op_c_i)],
+                regTmp1);
+
+            // Advance C ptr
+            mov(regCPtr, ptr[stackPtr + offsetof(dlp::kernels::gemmParams, c)]);
+            moveCPtr(regCPtr, regRsC, currentMR);
+            mov(ptr[stackPtr + offsetof(dlp::kernels::gemmParams, c)], regCPtr);
+
+            // Decrement m_iter
+            dec(regMiter);
+            jne(MIterLoop, T_NEAR);
+
+            L(considerMLeft);
+            mov(regMiter,
+                ptr[stackPtr + offsetof(dlp::kernels::gemmParams, mLeft)]);
+            test(regMiter, regMiter);
+            je(done_all, T_NEAR);
+
+            // Dispatch to fringe M labels
+            for (int mr_idx = MR - 1; mr_idx > 0; mr_idx--) {
+                cmp(regMiter, mr_idx);
+                je(m_labels[mr_idx - 1], T_NEAR);
+            }
+        } else {
+            jmp(done_all, T_NEAR);
+        }
+    }
+
+    L(done_all);
 
     vzeroupper();
 

--- a/src/jit/amdzen/f32_gemm_generator.hh
+++ b/src/jit/amdzen/f32_gemm_generator.hh
@@ -168,6 +168,8 @@ class jitGEMMF32 : public Xbyak::CodeGenerator
         utils::generatorParams& params);
     dlp::jit::jitGeneratorError generateKernel_IR_JR(
         utils::generatorParams& params);
+    dlp::jit::jitGeneratorError generateKernel_IR_JR_General(
+        utils::generatorParams& params);
     dlp::jit::jitGeneratorError generateKernelBodyK1(
         utils::generatorParams&       params,
         gen::kernelOpsHandler<KType>* kernelOpsHandlerPtr);

--- a/src/jit/amdzen/jit_generator_utils.hh
+++ b/src/jit/amdzen/jit_generator_utils.hh
@@ -96,7 +96,7 @@ struct generatorParams
     bool mLoop; // This will be set to true only for the main kernel
     bool is_k1; // this will be set to true only for the K=1 kernel where we
                 // need not generate k-unroll loop
-    bool nLoop; // this will be set to true for the nloop kernel where
+    bool nloop; // this will be set to true for the nloop kernel where
                 // both M and N loops are inside the JIT kernel
     dlp::kernel_frame::scalingType                    alphaScalingType;
     dlp::kernel_frame::scalingType                    betaScalingType;
@@ -126,7 +126,7 @@ struct generatorParams
         , useMask(_useMask)
         , mLoop(_mLoop)
         , is_k1(_is_k1)
-        , nLoop(false)
+        , nloop(false)
         , alphaScalingType(_alphaScalingType)
         , betaScalingType(_betaScalingType)
         , kType(_kType)
@@ -143,7 +143,7 @@ struct generatorParams
         , useMask(other.useMask)
         , mLoop(other.mLoop)
         , is_k1(other.is_k1)
-        , nLoop(other.nLoop)
+        , nloop(other.nloop)
         , alphaScalingType(other.alphaScalingType)
         , betaScalingType(other.betaScalingType)
         , kType(other.kType)
@@ -163,7 +163,7 @@ struct generatorParams
             useMask          = other.useMask;
             mLoop            = other.mLoop;
             is_k1            = other.is_k1;
-            nLoop            = other.nLoop;
+            nloop            = other.nloop;
             alphaScalingType = other.alphaScalingType;
             betaScalingType  = other.betaScalingType;
             kType            = other.kType;
@@ -182,7 +182,7 @@ struct generatorParams
         , useMask(other.useMask)
         , mLoop(other.mLoop)
         , is_k1(other.is_k1)
-        , nLoop(other.nLoop)
+        , nloop(other.nloop)
         , alphaScalingType(other.alphaScalingType)
         , betaScalingType(other.betaScalingType)
         , kType(other.kType)
@@ -202,7 +202,7 @@ struct generatorParams
             useMask          = other.useMask;
             mLoop            = other.mLoop;
             is_k1            = other.is_k1;
-            nLoop            = other.nLoop;
+            nloop            = other.nloop;
             alphaScalingType = other.alphaScalingType;
             betaScalingType  = other.betaScalingType;
             kType            = other.kType;

--- a/src/jit/amdzen/jit_generator_utils.hh
+++ b/src/jit/amdzen/jit_generator_utils.hh
@@ -96,6 +96,8 @@ struct generatorParams
     bool mLoop; // This will be set to true only for the main kernel
     bool is_k1; // this will be set to true only for the K=1 kernel where we
                 // need not generate k-unroll loop
+    bool nLoop; // this will be set to true for the nloop kernel where
+                // both M and N loops are inside the JIT kernel
     dlp::kernel_frame::scalingType                    alphaScalingType;
     dlp::kernel_frame::scalingType                    betaScalingType;
     kernelInstrType                                   kType;
@@ -124,6 +126,7 @@ struct generatorParams
         , useMask(_useMask)
         , mLoop(_mLoop)
         , is_k1(_is_k1)
+        , nLoop(false)
         , alphaScalingType(_alphaScalingType)
         , betaScalingType(_betaScalingType)
         , kType(_kType)
@@ -140,6 +143,7 @@ struct generatorParams
         , useMask(other.useMask)
         , mLoop(other.mLoop)
         , is_k1(other.is_k1)
+        , nLoop(other.nLoop)
         , alphaScalingType(other.alphaScalingType)
         , betaScalingType(other.betaScalingType)
         , kType(other.kType)
@@ -159,6 +163,7 @@ struct generatorParams
             useMask          = other.useMask;
             mLoop            = other.mLoop;
             is_k1            = other.is_k1;
+            nLoop            = other.nLoop;
             alphaScalingType = other.alphaScalingType;
             betaScalingType  = other.betaScalingType;
             kType            = other.kType;
@@ -177,6 +182,7 @@ struct generatorParams
         , useMask(other.useMask)
         , mLoop(other.mLoop)
         , is_k1(other.is_k1)
+        , nLoop(other.nLoop)
         , alphaScalingType(other.alphaScalingType)
         , betaScalingType(other.betaScalingType)
         , kType(other.kType)
@@ -196,6 +202,7 @@ struct generatorParams
             useMask          = other.useMask;
             mLoop            = other.mLoop;
             is_k1            = other.is_k1;
+            nLoop            = other.nLoop;
             alphaScalingType = other.alphaScalingType;
             betaScalingType  = other.betaScalingType;
             kType            = other.kType;


### PR DESCRIPTION
## Motivation

On the FP32 GEMM tiny path (`dlp_gemm_f32f32f32_tiny.c`), the framework loops over the N dimension in steps of NR and calls the per-NR-strip JIT kernel each iteration:

```c
for (iter_t jr = 0; jr < n; jr += NR) {
    md_t nr0 = dlp_min((n - jr), NR);
    dlp_execute_kernel(&handle, m, nr0, k, ..., post_op_list, post_ops_attr);
}
```

For tiny shapes with big N (small M, K but big N), the per-call setup — argument marshalling, post-op-attr update, indirect call through `kernel_base` — becomes a significant fraction of total kernel cost.

## Change

This PR adds an alternate JIT kernel variant — the **nr-loop kernel** — that internalizes the M-outer, N-middle, K-inner loop nest inside a single JIT-emitted kernel. The framework then issues exactly one call per (M, N, K) operation instead of `ceil(N/NR)` calls.

The mechanism:

1. **New JIT generator entry point** — `jitGEMMF32<KType>::generateKernel_IR_JR_General` (in `src/jit/amdzen/f32_gemm_generator.cc`) emits a kernel whose body contains:
   - An M-outer loop over `MR`-sized row panels with fringe MR labels for `MR-1, MR-2, ..., 1`.
   - An N-middle loop over `NR`-sized column panels with fringe NR variants (full + lt-mask) for the tail.
   - The existing K-inner loop, alpha/beta scaling, post-op dispatch, and store path — reused unchanged from the per-strip kernels.

2. **Generator dispatch** — a new boolean `generatorParams::nloop` (in `src/jit/amdzen/jit_generator_utils.hh`) routes generation through the new entry point. This matches the naming of the pre-existing `gemvM1GeneratorParams::nloop` field (same concept: "the JIT kernel emits an N-direction loop"). The dispatch lives at `f32_gemm_generator.cc:1415` and is read by FP32 only.

3. **Per-handle nr-loop kernel** — `jitAmdZenFP32::generateAllKernels` now additionally generates one nr-loop kernel per (MR, processBlockSize) handle, alongside the existing per-(mr, nr) variant set. Stored in new members `nloopKernelCodeBlock` / `nloopCodeGenerator` (see `src/jit/amdzen/amdzen_generator.{cc,hh}`).

4. **Runtime selection** — a new field `dlp_kernel_hndl_t::hasNLoop` (in `src/include/bindings/c_wrappers/capi_kernel_frame_wrappers.h`) records whether the handle has an nr-loop kernel available. A new C API `dlp_execute_kernel_nloop` invokes it. The tiny path checks `hasNLoop` and dispatches accordingly:

   ```c
   if (lcntx->dlp_kernel_hndl.kernel_base != NULL && lcntx->dlp_kernel_hndl.hasNLoop) {
       dlp_execute_kernel_nloop(&handle, m, n, k, ...);   // single call
   } else {
       for (iter_t jr = 0; jr < n; jr += NR) { ... }      // legacy per-strip
   }
   ```

5. **Base-class default** — `jitGeneratorBase::hasNLoop()` returns `false` (in `src/include/jit/jit_generator_base.hh`); only `jitAmdZenFP32` overrides. BF16, FP16, S8, U8S8, GEMV, batch-GEMM, and pack-B kernel adapters all inherit `false`, so the nr-loop path is reachable only when an FP32 tiny-path GEMM lands a handle whose JIT generator advertises `hasNLoop`.
