### PR TITLE
Fix UBSan invalid-shift-exponent in bf16 packa kernel

### DIFF
--- a/classic/kernels/zen4/bf16bf16f32/dlp_gemm_packa_bf16_amd256vnni.c
+++ b/classic/kernels/zen4/bf16bf16f32/dlp_gemm_packa_bf16_amd256vnni.c
@@ -526,7 +526,9 @@ dlp_packa_mr16_bf16bf16f32of32_row_major(bfloat16*       pack_a_buffer,
 
     md_t k_left = KC % 32;
 
-    __mmask32 mask = 0xFFFFFFFF >> (32 - k_left);
+    // Avoid shifting by the full width (UB) when KC is a multiple of 32; the
+    // mask is only used below when k_left > 0.
+    __mmask32 mask = (k_left > 0) ? (0xFFFFFFFF >> (32 - k_left)) : 0;
     __m512i   a_reg[32];
 
     md_t ic = 0, kr = 0;


### PR DESCRIPTION
`dlp_packa_mr16_bf16bf16f32of32_row_major` shifted a 32-bit unsigned by 32 when KC is a multiple of 32 (k_left == 0), which is UB. The mask is only consumed under if (k_left > 0) guards, so guard the shift to produce 0 in that case.